### PR TITLE
Provable Implementation

### DIFF
--- a/prototypes/smart-green-bond/contracts/SmartGreenBond.sol
+++ b/prototypes/smart-green-bond/contracts/SmartGreenBond.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 // import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "./interfaces/ISimpleBond.sol";
+import "./oracle/Oracle.sol";
 
 contract SmartGreenBond is ISimpleBond, Ownable {
     using SafeMath for uint256;
@@ -234,6 +235,14 @@ contract SmartGreenBond is ISimpleBond, Ownable {
         // Check to make sure that oracle update is due?
         // This is a security flaw: it can be called any time past 
         require(intervalCount.add(1).mul(couponThreshold) < block.number, 'An update to the variable rate is not yet due.');
+
+        
+        // TODO: Call the update____Mean method in the Oracle Contract.
+        // We will probably have to redeploy the contract and edit how to convert the 
+        // returned value and into a type that solidity will recognize.
+        // I also have to route the proper index to the method calls. 
+        // TODO: Figure out how to convert the string of the requested value into uint or floating point.
+
 
         // other checks on the input value?
         // We could have a range of possible values (from 0 to max variable payment) to reduce risks

--- a/prototypes/smart-green-bond/contracts/oracle/Oracle.sol
+++ b/prototypes/smart-green-bond/contracts/oracle/Oracle.sol
@@ -1,0 +1,131 @@
+// Contract Address: 0x1520d968810bCCc68AeAd2cb57413bf380775DE7 (ropsten)
+// To test go to Remix and deploy the contract at the address above.
+// Select the update function, wait for the transaction to complete, then click
+// on avgNoxValue, to view the requested result. 
+
+// NOTE: Requires enough ETH to make request. 
+pragma solidity ^0.6.0;
+
+import "github.com/oraclize/ethereum-api/provableAPI_0.6.sol";
+
+contract Oracle is usingProvable(){
+    
+    // The Public String of the mean- Call this variable to reveal the result
+    string public avgNoxValue;
+
+    event LogConstructorInitiated(string nextStep);
+    event LogPriceUpdated(string price);
+    event LogNewProvableQuery(string description);
+    event LogPath(string path);
+
+    constructor() payable public {
+        emit LogConstructorInitiated("Constructor was initiated. Call 'updatePrice()' to send the Provable Query.");
+    }
+    
+    function __callback(bytes32 myid, string memory result) public override {
+        if (msg.sender != provable_cbAddress()) revert();
+        avgNoxValue = result;
+        emit LogPriceUpdated(result);
+    }
+
+    function update2003Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/0).mean");
+        }
+    }
+    
+    function update2004Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/1).mean");
+        }
+    }
+    
+    function update2005Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/2).mean");
+        }
+    }
+    
+    function update2006Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/3).mean");
+        }
+    }
+    
+    function update2007Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/4).mean");
+        }
+    }
+    
+    function update2008Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/5).mean");
+        }
+    }
+    
+    function update2009Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/6).mean");
+        }
+    }
+    
+    function update2010Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/7).mean");
+        }
+    }
+    
+    function update2011Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/8).mean");
+        }
+    }
+    
+    function update2012Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/9).mean");
+        }
+    }
+    
+    function update2013Mean() payable public {
+        if (provable_getPrice("URL") > address(this).balance) {
+            emit LogNewProvableQuery("Provable query was NOT sent, please add some ETH to cover for the query fee");
+        } else {
+            emit LogNewProvableQuery("Provable query was sent, standing by for the answer..");
+            provable_query("URL", "json(https://calm-caverns-22873.herokuapp.com/data/10).mean");
+        }
+    }
+    
+    
+}


### PR DESCRIPTION
We have 10 request urls. The provable_query did not recognize the url value if I tried to submit a string variable into instead of the hardcoded values. So i just created 10 request functions that request the mean from their respective paths. I deployed this contract and the address of it is at the top of the contract. You can test it out on Remix.

TODOs include:
1) convert the response from a string into uint (provables response will always be a string so, there is no way to do this offchain). I will prob have to change the data in the API so it returns a rounded value, since Solidity doesnt support floating points. We could also use a library to replicate floating point numbers, although it might be expensive.

2) Route index to the proper updateMean method in Oracle.sol. So that we can simulate the value changing overtime. Provable allows for call delays and recursive calls, so we can have it call the methods automatically after a set amount of time. I think the max time limit is 60 days, but it should be enough to prove concept in the prototype and demo.